### PR TITLE
remove prettier recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,6 @@
   // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
     "stylelint.vscode-stylelint",
     "jpoissonnier.vscode-styled-components"
   ],


### PR DESCRIPTION
because it is alrady integrated into eslint, so no extension necessary