### PR TITLE
Feature/game end

### DIFF
--- a/src/boardgame/WizardState.ts
+++ b/src/boardgame/WizardState.ts
@@ -3,6 +3,7 @@ import { Ctx } from "boardgame.io";
 import { Card, generateCardDeck } from "./entities/cards";
 import { NumPlayers, PlayerID } from "./entities/players";
 import { Phase } from "./phases/phase";
+import { ScorePad } from "./entities/score";
 
 /**
  * Describes the Wizard game state used in the g object.
@@ -19,7 +20,7 @@ export interface WizardState {
   numCards: number;
   dealer: PlayerID;
   currentPlayer: PlayerID;
-  scorePad: ScoreRow[];
+  scorePad: ScorePad;
   numPlayers: NumPlayers;
   phase: Phase;
 }
@@ -80,31 +81,6 @@ export function isSetRound(
 }
 
 /**
- * Describes one row in the score pad:
- * Each's player score and bids for one specific round.
- *
- * @export
- * @interface ScoreRow
- */
-export interface ScoreRow {
-  numCards: number;
-  playerScores: Score[];
-}
-
-/**
- * A score entry in the score pad for one player and one round.
- *
- * @export
- * @interface Score
- */
-export interface Score {
-  bid: number;
-  tricks: number;
-  score: number;
-  total: number;
-}
-
-/**
  * Generates a WizardState with default values.
  *
  * @param {Ctx} ctx
@@ -128,7 +104,7 @@ export const generateDefaultWizardState = (
     round,
     trick,
     // TODO: set numCards to 1
-    numCards: 3,
+    numCards: 1,
     dealer: 0 as PlayerID,
     scorePad: [],
     numPlayers,

--- a/src/boardgame/entities/score.ts
+++ b/src/boardgame/entities/score.ts
@@ -1,4 +1,35 @@
-import { ScoreRow, Score } from "../WizardState";
+/**
+ * Describes the score pad aka "Block der Wahrheit"
+ * consisting of rows of player scores
+ *
+ * @export
+ */
+export type ScorePad = ScoreRow[];
+
+/**
+ * Describes one row in the score pad:
+ * Each's player score and bids for one specific round.
+ *
+ * @export
+ * @interface ScoreRow
+ */
+export interface ScoreRow {
+  numCards: number;
+  playerScores: Score[];
+}
+
+/**
+ * A score entry in the score pad for one player and one round.
+ *
+ * @export
+ * @interface Score
+ */
+export interface Score {
+  bid: number;
+  tricks: number;
+  score: number;
+  total: number;
+}
 
 export function updateScorePad(
   bids: (number | null)[],
@@ -32,3 +63,9 @@ export function calcRoundScore(
     playerScores,
   };
 }
+
+// export function getLeader(scorePad: ScorePad): number {
+//   if (!scorePad.length) throw new Error("cannot get leader of empty score pad");
+//   const latestRow = scorePad[scorePad.length - 1];
+//   return latestRow
+// }

--- a/src/boardgame/entities/score.ts
+++ b/src/boardgame/entities/score.ts
@@ -1,3 +1,5 @@
+import { PlayerID } from "./players";
+
 /**
  * Describes the score pad aka "Block der Wahrheit"
  * consisting of rows of player scores
@@ -64,8 +66,11 @@ export function calcRoundScore(
   };
 }
 
-// export function getLeader(scorePad: ScorePad): number {
-//   if (!scorePad.length) throw new Error("cannot get leader of empty score pad");
-//   const latestRow = scorePad[scorePad.length - 1];
-//   return latestRow
-// }
+export function getLeader(scorePad: ScorePad): PlayerID {
+  if (scorePad.length === 0)
+    throw new Error("cannot get leader of empty score pad");
+  const latestRow = scorePad[scorePad.length - 1];
+  return latestRow.playerScores.reduce((bestPlayerID, score, playerID, arr) => {
+    return score.total > arr[bestPlayerID].total ? playerID : bestPlayerID;
+  }, 0 as number) as PlayerID;
+}

--- a/src/boardgame/phases/playing.ts
+++ b/src/boardgame/phases/playing.ts
@@ -15,7 +15,7 @@ import {
   getTrickWinner,
   Rank,
 } from "../entities/cards";
-import { updateScorePad } from "../util/score";
+import { updateScorePad } from "../entities/score";
 import { Phase } from "./phase";
 
 export function play(

--- a/src/boardgame/phases/setup.ts
+++ b/src/boardgame/phases/setup.ts
@@ -37,9 +37,10 @@ export function handout(g: WizardState, ctx: Ctx): void {
   });
 
   round.hands = hands;
-  const trump = round.deck.pop();
-  if (!trump) throw new Error("deck seems to be empty");
-  round.trump = trump;
+  if (round.deck.length > 0) {
+    const trump = round.deck.pop();
+    round.trump = trump ?? null;
+  }
 
   ctx.events!.endPhase!();
 }

--- a/src/gameboard/WizardBoard.tsx
+++ b/src/gameboard/WizardBoard.tsx
@@ -6,6 +6,7 @@ import { PlayersContainer } from "./player/PlayersContainer";
 import { GameState } from "./GameState";
 import { Table } from "./table/Table";
 import { ScorePad } from "./score/ScorePad";
+import { FinalScoreModal } from "./gameover/FinalScoreModal";
 
 export const WizardBoard: React.FC<GameState> = (props) => {
   return (
@@ -16,6 +17,7 @@ export const WizardBoard: React.FC<GameState> = (props) => {
         <PlayersContainer />
         <ScorePad />
       </Container>
+      <FinalScoreModal />
     </GameContext.Provider>
   );
 };

--- a/src/gameboard/gameover/FinalScoreModal.tsx
+++ b/src/gameboard/gameover/FinalScoreModal.tsx
@@ -1,0 +1,34 @@
+import React, { useState, useContext, useEffect } from "react";
+import { Dialog, DialogTitle, Box } from "@material-ui/core";
+import styled from "styled-components";
+import { ScorePad } from "../score/ScorePad";
+import { GameContext } from "../GameContext";
+import { getLeader } from "../../boardgame/entities/score";
+
+export const FinalScoreModal: React.FC = () => {
+  const [showModal, setShowModal] = useState(false);
+  const { gamestate } = useContext(GameContext);
+  if (!gamestate) return null;
+
+  const {
+    ctx: { gameover },
+    G: { scorePad },
+  } = gamestate;
+  useEffect(() => {
+    setShowModal(!!gameover);
+  }, [gameover]);
+
+  const winner = showModal ? getLeader(scorePad) : "";
+  return (
+    <Dialog open={showModal}>
+      <Container>
+        <DialogTitle>Spieler {winner} gewinnt!</DialogTitle>
+        <ScorePad />
+      </Container>
+    </Dialog>
+  );
+};
+
+const Container = styled(Box)`
+  margin: 25px;
+`;


### PR DESCRIPTION
Changes:

- move score.ts file from /util to /entities and move Score-related interfaces from WizardState there.
- check deck is not empty before getting trump card to avoid error in last round
- add a FinalScoreModal which is shown when the game finishs announcing the game winner and displaying the final score pad