### PR TITLE
Feature/select trump

### DIFF
--- a/src/boardgame/WizardState.ts
+++ b/src/boardgame/WizardState.ts
@@ -1,6 +1,6 @@
 import shuffle from "lodash/shuffle";
 import { Ctx } from "boardgame.io";
-import { Card, generateCardDeck } from "./entities/cards";
+import { Card, generateCardDeck, Suit } from "./entities/cards";
 import { NumPlayers, PlayerID } from "./entities/players";
 import { Phase } from "./phases/phase";
 import { ScorePad } from "./entities/score";
@@ -46,8 +46,22 @@ export interface WizardRoundState {
   bids: (number | null)[];
   hands: Card[][];
   trickCount: number[];
-  trump: Card | null;
+  trump: Trump;
   deck: Card[];
+}
+
+/**
+ * Describes the round's trump suit.
+ * card: contains the trump card if given (i.e. not in the last round)
+ * suit: contains the trump suit. This is redudant to the card's suit most of the time
+ * but serves for the case when the trump card is a Z and the dealer selects a trump suit.
+ *
+ * @export
+ * @interface Trump
+ */
+export interface Trump {
+  card: Card | null;
+  suit?: Suit | null;
 }
 
 /**
@@ -126,7 +140,7 @@ export function generateBlankRoundState(
     bids: new Array(numPlayers).fill(null),
     hands: new Array(numPlayers).fill([]),
     trickCount: new Array(numPlayers).fill(null),
-    trump: null,
+    trump: { card: null },
     deck: shuffle(generateCardDeck()),
   };
 }

--- a/src/boardgame/entities/cards.ts
+++ b/src/boardgame/entities/cards.ts
@@ -9,6 +9,28 @@ export enum Suit {
 }
 export const allSuits = [Suit.Blue, Suit.Red, Suit.Yellow, Suit.Green];
 
+export enum SuitLabel {
+  Blue = "Blau",
+  Red = "Rot",
+  Yellow = "Gelb",
+  Green = "Grün",
+}
+
+export function getSuitLabel(suit: Suit): SuitLabel {
+  switch (suit) {
+    case Suit.Blue:
+      return SuitLabel.Blue;
+    case Suit.Red:
+      return SuitLabel.Red;
+    case Suit.Yellow:
+      return SuitLabel.Yellow;
+    case Suit.Green:
+      return SuitLabel.Green;
+    default:
+      throw new Error(`given argument is not a suit: ${suit}`);
+  }
+}
+
 export enum Rank {
   One = 1,
   Two,

--- a/src/boardgame/game.ts
+++ b/src/boardgame/game.ts
@@ -6,6 +6,7 @@ import { bidding } from "./phases/bidding";
 import { playing } from "./phases/playing";
 import { maxCards, PlayerID } from "./entities/players";
 import { Phase } from "./phases/phase";
+import { selectingTrump } from "./phases/selecting-trump";
 
 function endIf({ numCards, numPlayers }: WizardState): boolean {
   return numCards > maxCards(numPlayers);
@@ -33,6 +34,7 @@ export const wizardGameConfig = {
 
   phases: {
     [Phase.Setup]: setup,
+    [Phase.SelectingTrump]: selectingTrump,
     [Phase.Bidding]: bidding,
     [Phase.Playing]: playing,
   },

--- a/src/boardgame/phases/bidding.test.ts
+++ b/src/boardgame/phases/bidding.test.ts
@@ -34,7 +34,7 @@ function generate({
       bids,
       hands: new Array(ctx.numPlayers).fill(null),
       deck: [],
-      trump: null,
+      trump: { card: null },
       trickCount: new Array(ctx.numPlayers).fill(0),
     },
     trick: null,

--- a/src/boardgame/phases/phase.ts
+++ b/src/boardgame/phases/phase.ts
@@ -1,5 +1,6 @@
 export enum Phase {
   Setup = "setup",
+  SelectingTrump = "selecting-trump",
   Bidding = "bidding",
   Playing = "playing",
 }

--- a/src/boardgame/phases/selecting-trump.ts
+++ b/src/boardgame/phases/selecting-trump.ts
@@ -1,13 +1,28 @@
+/* eslint-disable no-param-reassign */
 import { Ctx, PhaseConfig } from "boardgame.io";
-import { WizardState } from "../WizardState";
-import { Suit } from "../entities/cards";
+import { INVALID_MOVE } from "boardgame.io/core";
+import { WizardState, isSetRound } from "../WizardState";
+import { Suit, allSuits } from "../entities/cards";
 import { Phase } from "./phase";
 
 export function selectTrump(
-  wizardState: WizardState,
+  { round }: WizardState,
   ctx: Ctx,
   suit: Suit
-): void {}
+): void | "INVALID_MOVE" {
+  if (!allSuits.includes(suit)) {
+    return INVALID_MOVE;
+  }
+  if (!isSetRound(round)) {
+    throw new Error("round is not set");
+  }
+
+  // set trump
+  round.trump.suit = suit;
+
+  // end phase
+  ctx.events!.endPhase!();
+}
 
 function first(g: WizardState, ctx: Ctx): number {
   return ctx.playOrder.findIndex(

--- a/src/boardgame/phases/selecting-trump.ts
+++ b/src/boardgame/phases/selecting-trump.ts
@@ -1,0 +1,29 @@
+import { Ctx, PhaseConfig } from "boardgame.io";
+import { WizardState } from "../WizardState";
+import { Suit } from "../entities/cards";
+import { Phase } from "./phase";
+
+export function selectTrump(
+  wizardState: WizardState,
+  ctx: Ctx,
+  suit: Suit
+): void {}
+
+function first(g: WizardState, ctx: Ctx): number {
+  return ctx.playOrder.findIndex(
+    (playerID) => playerID === g.dealer.toString()
+  );
+}
+
+export const selectingTrump: PhaseConfig = {
+  moves: {
+    selectTrump,
+  },
+  next: Phase.Bidding,
+  turn: {
+    order: {
+      // returns playOrder index of dealer
+      first,
+    },
+  },
+};

--- a/src/boardgame/phases/setup.test.ts
+++ b/src/boardgame/phases/setup.test.ts
@@ -32,7 +32,7 @@ describe("handout", () => {
       g.round!.deck.length - g.numCards * ctx.numPlayers - 1
     ];
     handout(g, ctx);
-    expect(g.round!.trump).toBe(expectedTrump);
+    expect(g.round!.trump.card).toBe(expectedTrump);
   });
 
   test("removes cards from deck when handing them out to players", () => {

--- a/src/boardgame/phases/setup.ts
+++ b/src/boardgame/phases/setup.ts
@@ -49,7 +49,6 @@ export function handout(g: WizardState, ctx: Ctx): void {
     if (trumpCard?.rank === Rank.Z) {
       trumpSuit = undefined;
     }
-    trumpSuit = undefined; // TODO: remove line
     round.trump = { card: trumpCard, suit: trumpSuit };
   }
 

--- a/src/boardgame/phases/setup.ts
+++ b/src/boardgame/phases/setup.ts
@@ -49,12 +49,13 @@ export function handout(g: WizardState, ctx: Ctx): void {
     if (trumpCard?.rank === Rank.Z) {
       trumpSuit = undefined;
     }
+    trumpSuit = undefined; // TODO: remove line
     round.trump = { card: trumpCard, suit: trumpSuit };
   }
 
   // go to next phase
   if (trumpSuit === undefined) {
-    ctx.events!.endPhase!({ next: Phase.SelectingTrump });
+    ctx.events!.setPhase!(Phase.SelectingTrump);
   } else {
     ctx.events!.endPhase!();
   }

--- a/src/boardgame/phases/setup.ts
+++ b/src/boardgame/phases/setup.ts
@@ -9,7 +9,7 @@ import {
   generateBlankRoundState,
 } from "../WizardState";
 import { playersRound, NumPlayers, PlayerID } from "../entities/players";
-import { Card } from "../entities/cards";
+import { Card, Rank, Suit } from "../entities/cards";
 import { Phase } from "./phase";
 
 export function shuffle({ round }: WizardState): void {
@@ -39,11 +39,25 @@ export function handout(g: WizardState, ctx: Ctx): void {
   round.hands = hands;
 
   // draw trump card
+  let trumpSuit: Suit | null | undefined;
   if (round.deck.length > 0) {
-    round.trump = round.deck.pop() ?? null;
+    const trumpCard = round.deck.pop() ?? null;
+    trumpSuit = trumpCard?.suit ?? null;
+    if (trumpCard?.rank === Rank.N) {
+      trumpSuit = null;
+    }
+    if (trumpCard?.rank === Rank.Z) {
+      trumpSuit = undefined;
+    }
+    round.trump = { card: trumpCard, suit: trumpSuit };
   }
 
-  ctx.events!.endPhase!();
+  // go to next phase
+  if (trumpSuit === undefined) {
+    ctx.events!.endPhase!({ next: Phase.SelectingTrump });
+  } else {
+    ctx.events!.endPhase!();
+  }
 }
 
 function onBegin(g: WizardState): void {

--- a/src/gameboard/player/Player.tsx
+++ b/src/gameboard/player/Player.tsx
@@ -8,6 +8,7 @@ import { PlayerOnBidding } from "./PlayerOnBidding";
 import { PlayerOnPlaying } from "./PlayerOnPlaying";
 import { TrickLabel } from "./TrickLabel";
 import { Phase } from "../../boardgame/phases/phase";
+import { PlayerOnSelectingTrump } from "./PlayerOnSelectingTrump";
 
 export const Player: React.FC<PlayerProps> = ({ playerID }) => {
   const { gamestate } = useContext(GameContext);
@@ -24,6 +25,9 @@ export const Player: React.FC<PlayerProps> = ({ playerID }) => {
       <PlayerTitle isTurn={isTurn}>{playerTitle}</PlayerTitle>
       <TrickLabel playerID={playerID} />
       {phase === Phase.Setup && <PlayerOnSetup playerID={playerID} />}
+      {phase === Phase.SelectingTrump && (
+        <PlayerOnSelectingTrump playerID={playerID} />
+      )}
       {phase === Phase.Bidding && <PlayerOnBidding playerID={playerID} />}
       {phase === Phase.Playing && <PlayerOnPlaying playerID={playerID} />}
     </Container>

--- a/src/gameboard/player/PlayerOnSelectingTrump.tsx
+++ b/src/gameboard/player/PlayerOnSelectingTrump.tsx
@@ -1,0 +1,121 @@
+import React, { useContext, useState } from "react";
+import {
+  Box,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  FormControl,
+  FormLabel,
+  Button,
+} from "@material-ui/core";
+import styled from "styled-components";
+import { GameContext } from "../GameContext";
+import { allSuits, Suit } from "../../boardgame/entities/cards";
+import { PlayCard, PlayCardColor } from "../components/PlayCard";
+import { PlayerProps } from "./Player.props";
+import { isSetRound } from "../../boardgame/WizardState";
+
+export const PlayerOnSelectingTrump: React.FC<PlayerProps> = ({ playerID }) => {
+  const { gamestate } = useContext(GameContext);
+  if (!gamestate) return null;
+  const {
+    G: { round, currentPlayer },
+    moves: { selectTrump },
+  } = gamestate;
+  if (!isSetRound(round)) {
+    throw new Error("round is not set");
+  }
+  const isTurn = currentPlayer === playerID;
+  const cards = round.hands[playerID];
+
+  const [selectedSuit, setSelectedSuit] = useState<Suit | null>(null);
+
+  return (
+    <Box>
+      {isTurn && (
+        <form>
+          <h5>Wähle eine Trump-Farbe</h5>
+          <FormControl component="fieldset">
+            <FormLabel component="legend">Trump-Farbe</FormLabel>
+            <RadioGroup
+              row
+              value={selectedSuit}
+              onChange={(event) => setSelectedSuit(event.target.value as Suit)}
+            >
+              {allSuits.map((suit) => (
+                <FormControlLabel
+                  value={suit}
+                  control={<SuitColoredRadio suit={suit} />}
+                  label={suit}
+                  key={suit}
+                />
+              ))}
+            </RadioGroup>
+          </FormControl>
+          {selectedSuit && (
+            <FormControl>
+              <Button
+                disabled={!selectedSuit}
+                onClick={() => selectTrump(selectedSuit)}
+              >
+                {selectedSuit} als Trumpf wählen
+              </Button>
+            </FormControl>
+          )}
+        </form>
+      )}
+      <CardsContainer>
+        {cards.map((card) => (
+          <PlayingCardContainer key={`${card.suit}-${card.rank}`}>
+            <PlayCard card={isTurn ? card : null} interactive={false} />
+          </PlayingCardContainer>
+        ))}
+      </CardsContainer>
+    </Box>
+  );
+};
+
+const CardsContainer = styled(Box)`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+`;
+
+const PlayingCardContainer = styled(Box)`
+  margin: 5px;
+`;
+
+// const SuitColoredRadio = withStyles({
+//   root: {
+//     color: "pink",
+//     "&$checked": {
+//       color: "red",
+//     },
+//   },
+//   checked: {},
+// })((props) => <Radio color="default" {...props} />);
+
+const SuitColoredRadio = styled(Radio)<{ suit: Suit }>`
+  &.MuiRadio-root {
+    color: ${({ suit }) => getColor(suit)};
+    /* &.Mui-checked {
+      color: green;
+    } */
+  }
+`;
+
+function getColor(suit: Suit): PlayCardColor {
+  switch (suit) {
+    case Suit.Blue:
+      return PlayCardColor.Blue;
+    case Suit.Green:
+      return PlayCardColor.Green;
+    case Suit.Red:
+      return PlayCardColor.Red;
+    case Suit.Yellow:
+      return PlayCardColor.Yellow;
+    // fallback
+    default:
+      return PlayCardColor.Black;
+  }
+}

--- a/src/gameboard/player/PlayerOnSelectingTrump.tsx
+++ b/src/gameboard/player/PlayerOnSelectingTrump.tsx
@@ -19,7 +19,7 @@ export const PlayerOnSelectingTrump: React.FC<PlayerProps> = ({ playerID }) => {
   const { gamestate } = useContext(GameContext);
   if (!gamestate) return null;
   const {
-    G: { round, currentPlayer },
+    wizardState: { round, currentPlayer },
     moves: { selectTrump },
   } = gamestate;
   if (!isSetRound(round)) {

--- a/src/gameboard/player/PlayerOnSelectingTrump.tsx
+++ b/src/gameboard/player/PlayerOnSelectingTrump.tsx
@@ -35,7 +35,7 @@ export const PlayerOnSelectingTrump: React.FC<PlayerProps> = ({ playerID }) => {
       {isTurn && (
         <Form>
           <FormControl component="fieldset">
-            <FormLabel component="legend">Wähle eine Trump-Farbe</FormLabel>
+            <FormLabel component="legend">Wähle eine Trumpf-Farbe</FormLabel>
             <RadioGroup
               row
               value={selectedSuit}

--- a/src/gameboard/player/PlayerOnSelectingTrump.tsx
+++ b/src/gameboard/player/PlayerOnSelectingTrump.tsx
@@ -33,10 +33,9 @@ export const PlayerOnSelectingTrump: React.FC<PlayerProps> = ({ playerID }) => {
   return (
     <Box>
       {isTurn && (
-        <form>
-          <h5>Wähle eine Trump-Farbe</h5>
+        <Form>
           <FormControl component="fieldset">
-            <FormLabel component="legend">Trump-Farbe</FormLabel>
+            <FormLabel component="legend">Wähle eine Trump-Farbe</FormLabel>
             <RadioGroup
               row
               value={selectedSuit}
@@ -52,17 +51,21 @@ export const PlayerOnSelectingTrump: React.FC<PlayerProps> = ({ playerID }) => {
               ))}
             </RadioGroup>
           </FormControl>
-          {selectedSuit && (
-            <FormControl>
-              <Button
-                disabled={!selectedSuit}
-                onClick={() => selectTrump(selectedSuit)}
-              >
-                {getSuitLabel(selectedSuit)} als Trumpf wählen
-              </Button>
-            </FormControl>
-          )}
-        </form>
+          <ButtonContainer>
+            {selectedSuit && (
+              <FormControl>
+                <Button
+                  color="primary"
+                  variant="contained"
+                  disabled={!selectedSuit}
+                  onClick={() => selectTrump(selectedSuit)}
+                >
+                  {getSuitLabel(selectedSuit)} als Trumpf wählen
+                </Button>
+              </FormControl>
+            )}
+          </ButtonContainer>
+        </Form>
       )}
       <CardsContainer>
         {cards.map((card) => (
@@ -74,6 +77,15 @@ export const PlayerOnSelectingTrump: React.FC<PlayerProps> = ({ playerID }) => {
     </Box>
   );
 };
+
+const Form = styled.form`
+  margin: 20px 0;
+`;
+
+const ButtonContainer = styled(Box)`
+  height: 40px;
+  margin: 10px 0;
+`;
 
 const CardsContainer = styled(Box)`
   display: flex;

--- a/src/gameboard/player/PlayerOnSelectingTrump.tsx
+++ b/src/gameboard/player/PlayerOnSelectingTrump.tsx
@@ -10,7 +10,7 @@ import {
 } from "@material-ui/core";
 import styled from "styled-components";
 import { GameContext } from "../GameContext";
-import { allSuits, Suit } from "../../boardgame/entities/cards";
+import { allSuits, Suit, getSuitLabel } from "../../boardgame/entities/cards";
 import { PlayCard, PlayCardColor } from "../components/PlayCard";
 import { PlayerProps } from "./Player.props";
 import { isSetRound } from "../../boardgame/WizardState";
@@ -46,7 +46,7 @@ export const PlayerOnSelectingTrump: React.FC<PlayerProps> = ({ playerID }) => {
                 <FormControlLabel
                   value={suit}
                   control={<SuitColoredRadio suit={suit} />}
-                  label={suit}
+                  label={getSuitLabel(suit)}
                   key={suit}
                 />
               ))}
@@ -58,7 +58,7 @@ export const PlayerOnSelectingTrump: React.FC<PlayerProps> = ({ playerID }) => {
                 disabled={!selectedSuit}
                 onClick={() => selectTrump(selectedSuit)}
               >
-                {selectedSuit} als Trumpf wählen
+                {getSuitLabel(selectedSuit)} als Trumpf wählen
               </Button>
             </FormControl>
           )}

--- a/src/gameboard/table/Deck.tsx
+++ b/src/gameboard/table/Deck.tsx
@@ -1,10 +1,10 @@
 import React, { useContext } from "react";
 import styled from "styled-components";
 import { Box } from "@material-ui/core";
-import { Suit, Card } from "../../boardgame/entities/cards";
+import { Suit } from "../../boardgame/entities/cards";
 import { PlayCard, PlayCardColor } from "../components/PlayCard";
 import { GameContext } from "../GameContext";
-import { isSetRound } from "../../boardgame/WizardState";
+import { isSetRound, Trump } from "../../boardgame/WizardState";
 
 export const Deck: React.FC = () => {
   const { gamestate } = useContext(GameContext);
@@ -21,7 +21,7 @@ export const Deck: React.FC = () => {
   return (
     <Container>
       <DeckContainer trump={color}>
-        <PlayCard card={trump || null} interactive={false} />
+        <PlayCard card={trump.card} interactive={false} />
       </DeckContainer>
     </Container>
   );
@@ -42,8 +42,7 @@ const DeckContainer = styled(Box)<{ trump: string }>`
   border-radius: 50%;
 `;
 
-function getColor(trump?: Card | null): string {
-  if (!trump) return "lightgrey";
+function getColor(trump: Trump): string {
   switch (trump.suit) {
     case Suit.Blue:
       return PlayCardColor.Blue;
@@ -53,8 +52,10 @@ function getColor(trump?: Card | null): string {
       return PlayCardColor.Red;
     case Suit.Yellow:
       return PlayCardColor.Yellow;
+    case null:
+      return PlayCardColor.Black;
     // fallback
     default:
-      return PlayCardColor.Black;
+      return "lightgrey";
   }
 }


### PR DESCRIPTION
resolves #1 

Changes:

- changes the structure of the `wizardState.round.trump` field to `{card: Card, suit?: Suit}`. To handle trump if the trump card is a Z.
- add `selectingTrump` phase and corresponding Player component
-  in the `setup` phase : handle the setting of a trumpregarding the special cases of N and Z trump cards.
- in the setup phase: jumps to the `selectingTrump` phase if trump card is a Z
- add German labels for the suits, used during trump selection in case of a Z trump card.
- adjust the `Deck` component to play along with the trump special cases