### PR TITLE
Bugfix/turn on begin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "source.fixAll": true
   },
   "editor.formatOnSave": false,
-  "files.eol": "\n"
+  "files.eol": "\n",
+  "editor.tabSize": 2
 }

--- a/src/boardgame/game.ts
+++ b/src/boardgame/game.ts
@@ -1,27 +1,15 @@
 /* eslint-disable no-param-reassign */
-import { Ctx } from "boardgame.io";
 import { generateDefaultWizardState, WizardState } from "./WizardState";
 import { setup } from "./phases/setup";
 import { bidding } from "./phases/bidding";
 import { playing } from "./phases/playing";
-import { maxCards, PlayerID } from "./entities/players";
+import { maxCards } from "./entities/players";
 import { Phase } from "./phases/phase";
 import { selectingTrump } from "./phases/selecting-trump";
+import { onBeginTurn } from "./turn";
 
 function endIf({ numCards, numPlayers }: WizardState): boolean {
   return numCards > maxCards(numPlayers);
-}
-
-function onEnd(g: WizardState): void {
-  // TODO: handle game end
-  console.log("GAME ENDED", g.currentPlayer);
-}
-
-function onBeginTurn(g: WizardState, ctx: Ctx): void {
-  // sync ctx.currentPlayer (string) to g.currentPlayer (number)
-  g.currentPlayer = Number.parseInt(ctx.currentPlayer, 10) as PlayerID;
-  // also sync phase to g
-  g.phase = ctx.phase as Phase;
 }
 
 export const wizardGameConfig = {
@@ -39,5 +27,4 @@ export const wizardGameConfig = {
     [Phase.Playing]: playing,
   },
   endIf,
-  onEnd,
 };

--- a/src/boardgame/phases/selecting-trump.ts
+++ b/src/boardgame/phases/selecting-trump.ts
@@ -4,6 +4,7 @@ import { INVALID_MOVE } from "boardgame.io/core";
 import { WizardState, isSetRound } from "../WizardState";
 import { Suit, allSuits } from "../entities/cards";
 import { Phase } from "./phase";
+import { onBeginTurn } from "../turn";
 
 export function selectTrump(
   { round }: WizardState,
@@ -40,5 +41,6 @@ export const selectingTrump: PhaseConfig = {
       // returns playOrder index of dealer
       first,
     },
+    onBegin: onBeginTurn,
   },
 };

--- a/src/boardgame/phases/setup.ts
+++ b/src/boardgame/phases/setup.ts
@@ -11,6 +11,7 @@ import {
 import { playersRound, NumPlayers, PlayerID } from "../entities/players";
 import { Card, Rank, Suit } from "../entities/cards";
 import { Phase } from "./phase";
+import { onBeginTurn } from "../turn";
 
 export function shuffle({ round }: WizardState): void {
   round!.deck = shuffleUtil(round!.deck);
@@ -93,5 +94,6 @@ export const setup: PhaseConfig = {
       // returns playOrder index of dealer
       first,
     },
+    onBegin: onBeginTurn,
   },
 };

--- a/src/boardgame/turn.ts
+++ b/src/boardgame/turn.ts
@@ -1,0 +1,15 @@
+/* eslint-disable no-param-reassign */
+import { Ctx } from "boardgame.io";
+import { WizardState } from "./WizardState";
+import { PlayerID } from "./entities/players";
+import { Phase } from "./phases/phase";
+
+export function onBeginTurn(wizardState: WizardState, ctx: Ctx): void {
+  // sync ctx.currentPlayer (string) to wizardState.currentPlayer (number)
+  wizardState.currentPlayer = Number.parseInt(
+    ctx.currentPlayer,
+    10
+  ) as PlayerID;
+  // also sync phase to wizardState
+  wizardState.phase = ctx.phase as Phase;
+}


### PR DESCRIPTION
fixes #17 

Da die Phasen `setup` und `selecting-trump` in der Konfiguration das `turn` Feld setzen um mit `order.first()` manuell den Anfangsspieler dieser Phase zu bestimmen wurde die globale `turn.onBegin()` überschrieben. 

Changes:

- die Funktion `onBeginTurn` in eigene Datei extrahieren und sowohl in der game config als auch in den betroffenenen Phasen importieren und im `turn`-Feld setzen.
- `.vscode/settings.json` Standard Tab-Width auf 2 setzen um den ESLint Einstellungen zu entsprechen.