### PR TITLE
Feature/header rework

### DIFF
--- a/src/boardgame/WizardState.ts
+++ b/src/boardgame/WizardState.ts
@@ -44,6 +44,7 @@ export interface WizardTrickState {
  */
 export interface WizardRoundState {
   bids: (number | null)[];
+  bidsMismatch?: number;
   hands: Card[][];
   trickCount: number[];
   trump: Trump;

--- a/src/boardgame/phases/bidding.ts
+++ b/src/boardgame/phases/bidding.ts
@@ -4,7 +4,7 @@ import { INVALID_MOVE } from "boardgame.io/core";
 import groupBy from "lodash/groupBy";
 import flatten from "lodash/flatten";
 import { WizardState, isSetRound } from "../WizardState";
-import { isValidBid } from "../util/bid";
+import { isValidBid, getBidsMismatch } from "../util/bid";
 import { Phase } from "./phase";
 import { Rank } from "../entities/cards";
 
@@ -59,11 +59,22 @@ function endIf({ round }: WizardState): boolean {
   return !round.bids.includes(null);
 }
 
+function onEnd({ round, numCards }: WizardState): void {
+  if (!isSetRound(round)) {
+    throw new Error("round is not set");
+  }
+  if (round.bids.includes(null)) {
+    throw new Error("bids are not complete");
+  }
+  round.bidsMismatch = getBidsMismatch(round.bids as number[], numCards);
+}
+
 export const bidding: PhaseConfig = {
   moves: {
     bid,
     sortCards,
   },
   endIf,
+  onEnd,
   next: Phase.Playing,
 };

--- a/src/boardgame/util/bid.ts
+++ b/src/boardgame/util/bid.ts
@@ -22,3 +22,7 @@ export function isValidBid(
   }
   return true;
 }
+
+export function getBidsMismatch(bids: number[], numCards: number): number {
+  return bids.reduce((a, b) => a + b, 0) - numCards;
+}

--- a/src/gameboard/header/HeaderBar.tsx
+++ b/src/gameboard/header/HeaderBar.tsx
@@ -3,20 +3,30 @@ import { AppBar, Box, Toolbar } from "@material-ui/core";
 import styled from "styled-components";
 
 import { useGameState } from "../GameContext";
+import { maxCards } from "../../boardgame/entities/players";
 
 export const HeaderBar: React.FC = () => {
   const {
-    wizardState: { phase, currentPlayer, numCards, numPlayers },
+    wizardState: { numCards, numPlayers, round },
   } = useGameState();
   return (
     <AppBar position="sticky">
       <Toolbar>
         <h1>Wizard Online</h1>
         <SpaceFill />
-        <InfoItem>Phase: {phase}</InfoItem>
-        <InfoItem>PlayerId: {currentPlayer}</InfoItem>
-        <InfoItem>Runde: {numCards}</InfoItem>
-        <InfoItem>#Spieler: {numPlayers}</InfoItem>
+        {round && round.bidsMismatch !== undefined && (
+          <InfoItem>
+            {round.bidsMismatch > 0 && "+"}
+            {round.bidsMismatch} Stiche Abweichung{" "}
+            {round.bidsMismatch > 0 && "(offensiv)"}
+            {round.bidsMismatch < 0 && "(defensiv)"}
+            {round.bidsMismatch === 0 && "(ausgeglichen)"}
+          </InfoItem>
+        )}
+        <InfoItem>
+          Runde {numCards} / {maxCards(numPlayers)}
+        </InfoItem>
+        <InfoItem>{numPlayers} Spieler</InfoItem>
       </Toolbar>
     </AppBar>
   );
@@ -27,5 +37,5 @@ const SpaceFill = styled.div`
 `;
 
 const InfoItem = styled(Box)`
-  margin: 8px;
+  margin: 15px;
 `;


### PR DESCRIPTION
resolves #4 and #21 

Changes:

- add `wizardState.round.bidsMismatch` field containing the difference between total bid sum and number of cards
- add `onEnd` function to `bidding` phase to calculate and set the `bidsMismatch` field
- remove some unnecessary information from `HeaderBar` and add bids mismatch

not done in this PR: restyling of the header bar