### PR TITLE
Bugfix/trick winner on lead n

### DIFF
--- a/src/game/entities/cards.test.ts
+++ b/src/game/entities/cards.test.ts
@@ -228,19 +228,6 @@ describe("getTrickWinner", () => {
     );
   });
 
-  test("first N wins if only Ns", () => {
-    const { cards, trumpSuit, winnerIndex }: TestData = {
-      cards: [
-        [Card(Suit.Red, Rank.N), 2],
-        [Card(Suit.Yellow, Rank.N), 0],
-        [Card(Suit.Blue, Rank.N), 1],
-      ],
-      trumpSuit: Suit.Green,
-      winnerIndex: 0,
-    };
-    expect(getTrickWinner(cards, trumpSuit)).toEqual(cards[winnerIndex]);
-  });
-
   test("highest leading rank wins without trump and z", () => {
     const data: TestData[] = [
       {
@@ -302,6 +289,78 @@ describe("getTrickWinner", () => {
     data.forEach(({ cards, trumpSuit, winnerIndex }) =>
       expect(getTrickWinner(cards, trumpSuit)).toEqual(cards[winnerIndex])
     );
+  });
+
+  describe("on first card N", () => {
+    test("first N wins if only Ns", () => {
+      const { cards, trumpSuit, winnerIndex }: TestData = {
+        cards: [
+          [Card(Suit.Red, Rank.N), 2],
+          [Card(Suit.Yellow, Rank.N), 0],
+          [Card(Suit.Blue, Rank.N), 1],
+        ],
+        trumpSuit: Suit.Green,
+        winnerIndex: 0,
+      };
+      expect(getTrickWinner(cards, trumpSuit)).toEqual(cards[winnerIndex]);
+    });
+
+    test("highest trump wins without z", () => {
+      const data: TestData[] = [
+        {
+          cards: [
+            [Card(Suit.Red, Rank.N), 3],
+            [Card(Suit.Green, 1), 0],
+            [Card(Suit.Red, 13), 1],
+            [Card(Suit.Green, 9), 2],
+          ],
+          trumpSuit: Suit.Green,
+          winnerIndex: 3,
+        },
+        {
+          cards: [
+            [Card(Suit.Blue, Rank.N), 0],
+            [Card(Suit.Blue, 2), 1],
+            [Card(Suit.Red, 9), 2],
+            [Card(Suit.Blue, 1), 3],
+          ],
+          trumpSuit: Suit.Blue,
+          winnerIndex: 1,
+        },
+      ];
+
+      data.forEach(({ cards, trumpSuit, winnerIndex }) =>
+        expect(getTrickWinner(cards, trumpSuit)).toEqual(cards[winnerIndex])
+      );
+    });
+
+    test("highest leading rank wins without trump and z", () => {
+      const data: TestData[] = [
+        {
+          cards: [
+            [Card(Suit.Red, Rank.N), 0],
+            [Card(Suit.Yellow, 13), 1],
+            [Card(Suit.Red, 9), 2],
+          ],
+          trumpSuit: Suit.Green,
+          winnerIndex: 1,
+        },
+        {
+          cards: [
+            [Card(Suit.Blue, Rank.N), 2],
+            [Card(Suit.Blue, 2), 3],
+            [Card(Suit.Red, 9), 0],
+            [Card(Suit.Blue, 5), 1],
+          ],
+          trumpSuit: Suit.Green,
+          winnerIndex: 3,
+        },
+      ];
+
+      data.forEach(({ cards, trumpSuit, winnerIndex }) =>
+        expect(getTrickWinner(cards, trumpSuit)).toEqual(cards[winnerIndex])
+      );
+    });
   });
 });
 

--- a/src/game/entities/cards.test.ts
+++ b/src/game/entities/cards.test.ts
@@ -8,6 +8,7 @@ import {
   getTrickWinner,
   canPlayCard,
   playableCardsInHand,
+  getLeadSuit,
 } from "./cards";
 import { PlayerID } from "./players";
 
@@ -485,5 +486,114 @@ describe("playableCardsInHand", () => {
       true,
       true,
     ]);
+  });
+});
+
+describe("getLeadSuit", () => {
+  test("returns suit of first card if it has regular rank", () => {
+    const testData = [
+      {
+        cards: [Card(Suit.Blue, 4), Card(Suit.Red, 9), Card(Suit.Red, 13)],
+        expected: Suit.Blue,
+      },
+      {
+        cards: [
+          Card(Suit.Green, 13),
+          Card(Suit.Red, Rank.Z),
+          Card(Suit.Red, 13),
+        ],
+        expected: Suit.Green,
+      },
+      {
+        cards: [
+          Card(Suit.Red, 1),
+          Card(Suit.Yellow, 1),
+          Card(Suit.Red, Rank.N),
+        ],
+        expected: Suit.Red,
+      },
+      {
+        cards: [
+          Card(Suit.Yellow, 4),
+          Card(Suit.Yellow, Rank.N),
+          Card(Suit.Red, 13),
+        ],
+        expected: Suit.Yellow,
+      },
+    ];
+
+    testData.forEach(({ cards, expected }) => {
+      expect(getLeadSuit(cards)).toBe(expected);
+    });
+  });
+
+  test("returns suit of first regular rank card if first card is N", () => {
+    const testData = [
+      {
+        cards: [Card(Suit.Blue, Rank.N), Card(Suit.Red, 9), Card(Suit.Red, 13)],
+        expected: Suit.Red,
+      },
+      {
+        cards: [
+          Card(Suit.Green, Rank.N),
+          Card(Suit.Red, Rank.N),
+          Card(Suit.Yellow, 4),
+          Card(Suit.Green, 13),
+        ],
+        expected: Suit.Yellow,
+      },
+    ];
+
+    testData.forEach(({ cards, expected }) => {
+      expect(getLeadSuit(cards)).toBe(expected);
+    });
+  });
+
+  test("retuns null if all cards are Ns", () => {
+    const testData = [
+      {
+        cards: [
+          Card(Suit.Blue, Rank.N),
+          Card(Suit.Red, Rank.N),
+          Card(Suit.Red, Rank.N),
+        ],
+      },
+      {
+        cards: [
+          Card(Suit.Green, Rank.N),
+          Card(Suit.Red, Rank.N),
+          Card(Suit.Yellow, Rank.N),
+          Card(Suit.Blue, Rank.N),
+        ],
+      },
+    ];
+
+    testData.forEach(({ cards }) => {
+      expect(getLeadSuit(cards)).toBeNull();
+    });
+  });
+
+  test("returns undefined if first card is Z", () => {
+    const testData = [
+      {
+        cards: [
+          Card(Suit.Blue, Rank.Z),
+          Card(Suit.Red, 13),
+          Card(Suit.Green, 4),
+        ],
+      },
+      {
+        cards: [
+          Card(Suit.Green, Rank.N),
+          Card(Suit.Red, Rank.Z),
+          Card(Suit.Yellow, 1),
+          Card(Suit.Blue, 7),
+        ],
+      },
+    ];
+
+    testData.forEach(({ cards }) => {
+      expect(getLeadSuit(cards)).toBeUndefined();
+    });
   });
 });

--- a/src/game/entities/cards.ts
+++ b/src/game/entities/cards.ts
@@ -128,7 +128,7 @@ export function getTrickWinner(
   if (cards.length < 2) {
     throw new Error("too few cards");
   }
-  const leadSuit = cards[0][0].suit;
+  const leadSuit = getLeadSuit(cards.map(([card]) => card));
   const winner = cards.reduce((winningCard, card, cardIndex) => {
     // skip first card
     if (cardIndex === 0) return winningCard;
@@ -136,6 +136,27 @@ export function getTrickWinner(
     return beaten ? card : winningCard;
   }, cards[0]);
   return winner;
+}
+
+/**
+ * returns the lead suit of a given trick
+ *
+ * @export
+ * @param {Card[]} cards
+ * @returns {(Suit | null | undefined)} suit of lead card or null if all cards a Ns or undefined if lead card is Z
+ */
+export function getLeadSuit(cards: Card[]): Suit | null | undefined {
+  if (cards.length === 0) {
+    return null;
+  }
+  const leadCard = cards[0];
+  if (leadCard.rank === Rank.Z) {
+    return undefined;
+  }
+  if (leadCard.rank === Rank.N) {
+    return getLeadSuit(cards.slice(1));
+  }
+  return leadCard.suit;
 }
 
 export function getSuitsInHand(hand: Card[]): Suit[] {

--- a/src/game/entities/cards.ts
+++ b/src/game/entities/cards.ts
@@ -72,10 +72,28 @@ export interface Card {
   rank: Rank;
 }
 
+/**
+ * quick factory to create card objects
+ *
+ * @export
+ * @param {Suit} suit
+ * @param {Rank} rank
+ * @returns {Card}
+ */
 export function Card(suit: Suit, rank: Rank): Card {
   return { suit, rank };
 }
 
+/**
+ * checks if a card wins over another card given specified trump and lead suits
+ *
+ * @export
+ * @param {Card} card card to check
+ * @param {Card} other card to be compared with
+ * @param {(Suit | null)} [trumpSuit=null] suit of the trump card
+ * @param {(Suit | null)} [leadSuit=null] suit of the lead card
+ * @returns {boolean}
+ */
 export function cardBeatsOther(
   card: Card,
   other: Card,
@@ -121,6 +139,14 @@ export function cardBeatsOther(
   return false;
 }
 
+/**
+ * gets the winner of a trick
+ *
+ * @export
+ * @param {[Card, PlayerID][]} cards
+ * @param {(Suit | null)} trumpSuit
+ * @returns {[Card, PlayerID]}
+ */
 export function getTrickWinner(
   cards: [Card, PlayerID][],
   trumpSuit: Suit | null
@@ -139,7 +165,7 @@ export function getTrickWinner(
 }
 
 /**
- * returns the lead suit of a given trick
+ * gets the lead suit of a given trick
  *
  * @export
  * @param {Card[]} cards
@@ -159,6 +185,13 @@ export function getLeadSuit(cards: Card[]): Suit | null | undefined {
   return leadCard.suit;
 }
 
+/**
+ * gets a list of all suits in a player's hand
+ *
+ * @export
+ * @param {Card[]} hand the player's hand
+ * @returns {Suit[]} set of suits in the player's hand
+ */
 export function getSuitsInHand(hand: Card[]): Suit[] {
   return allSuits.filter((suit) =>
     hand.find(
@@ -168,10 +201,19 @@ export function getSuitsInHand(hand: Card[]): Suit[] {
   );
 }
 
+/**
+ * checks if a specified card can be played given the available suits in the player's hand and the trick's lead card
+ *
+ * @export
+ * @param {Card} card card to be checked
+ * @param {Suit[]} suitsInHand set of suits in the players hand
+ * @param {(Card | null)} leadCard lead card or undefined if player is first in a trick
+ * @returns {boolean}
+ */
 export function canPlayCard(
   card: Card,
   suitsInHand: Suit[],
-  leadCard: Card | null
+  leadCard?: Card
 ): boolean {
   // as lead, every card can be played
   if (!leadCard) {
@@ -197,14 +239,26 @@ export function canPlayCard(
   return card.suit === leadCard.suit;
 }
 
-export function playableCardsInHand(
-  hand: Card[],
-  leadCard: Card | null
-): boolean[] {
+/**
+ * returns a boolean list of which cards in a player's hand are playable given a lead card
+ *
+ * @export
+ * @param {Card[]} hand
+ * @param {Card} [leadCard]
+ * @returns {boolean[]}
+ */
+export function playableCardsInHand(hand: Card[], leadCard?: Card): boolean[] {
   const suitsInHand = getSuitsInHand(hand);
   return hand.map((card) => canPlayCard(card, suitsInHand, leadCard));
 }
 
+/**
+ * generates a new card deck instance
+ *
+ * @export
+ * @param {Rank[]} [ranks=allRanks]
+ * @returns {Card[]}
+ */
 export function generateCardDeck(ranks: Rank[] = allRanks): Card[] {
   const cards = flatten(
     allSuits.map((suit) => ranks.map((rank) => ({ suit, rank })))
@@ -213,6 +267,18 @@ export function generateCardDeck(ranks: Rank[] = allRanks): Card[] {
   return cards;
 }
 
+/**
+ * sorts the cards in a hand by the following scheme:
+ * Ns come always to the left, Zs come always to the right
+ * trump cards come next to the Zs
+ * non-trump cards are sorted by the amount of cards of one suit
+ * cards of the same suit are sorted by their rank
+ *
+ * @export
+ * @param {Card[]} hand list of cards to be sorted
+ * @param {(Suit | null)} [trumpSuit]
+ * @returns {Card[]} the sorted cards
+ */
 export function sortHand(hand: Card[], trumpSuit?: Suit | null): Card[] {
   // group cards by suit / N / Z
   const groupedHand = groupBy(hand, (card) => {

--- a/src/game/phases/playing.ts
+++ b/src/game/phases/playing.ts
@@ -33,7 +33,7 @@ export function play(
     return INVALID_MOVE;
   }
   const card = hand[cardIndex];
-  if (!canPlayCard(card, getSuitsInHand(hand), g.trick?.lead || null)) {
+  if (!canPlayCard(card, getSuitsInHand(hand), g.trick?.lead)) {
     return INVALID_MOVE;
   }
 

--- a/src/ui/player/PlayerHand.tsx
+++ b/src/ui/player/PlayerHand.tsx
@@ -18,7 +18,7 @@ export const PlayerHand: React.FC<HandCardsProps> = ({
 }) => {
   const playableCards =
     isInteractive && !cards.includes(null)
-      ? playableCardsInHand(cards as Card[], lead || null)
+      ? playableCardsInHand(cards as Card[], lead)
       : undefined;
 
   return (


### PR DESCRIPTION
fixes #46 

- add tests for `getTrickWinner` cases where first card is a N
- add function `getLeadSuit`
- add tests for function `getLeadSuit` 
- add documentation to cards functions
- use `undefined` as optional type for `leadCard` in `canPlayCard` instead of `null`